### PR TITLE
fix: add `@angular/compiler-cli` and `typescript` to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "peerDependencies": {
     "@angular/compiler": "~5.1.0",
-    "@angular/core": "~5.1.0"
+    "@angular/compiler-cli": "~5.1.0",
+    "@angular/core": "~5.1.0",
+    "typescript": "~2.5.0"
   },
   "devDependencies": {
     "@angular/common": "5.1.0",


### PR DESCRIPTION
Adding just `@angular/compiler` and `@angular/core`, will cause an Error "Cannot find module" for the compiler-cli and typescript. This change adds both to the peerDepdencies, although - in most cases - users will have them probably installed in an Angular project.

From `ngast.bundle.js`:

```js
(function (global, factory) {
	typeof exports === 'object' && typeof module !== 'undefined' ? 
              factory(exports,
                            require('@angular/core'),
                            require('@angular/compiler'),
                            require('@angular/compiler-cli'),
                            require('typescript')) :
	typeof define === 'function' && define.amd ? define(['exports',
                            '@angular/core',
                            '@angular/compiler',
                            '@angular/compiler-cli',
                            'typescript'
        ], factory) :
	(factory((global.ngast = global.ngast || {}),global._angular_core,global._angular_compiler,global._angular_compilerCli,global.ts));
}(this, (function (exports,_angular_core,_angular_compiler,_angular_compilerCli,ts) { 'use strict';
/* ... */
```
