### PR TITLE
fix: replace backslashes in rootNames with forward slashes.

### DIFF
--- a/lib/project-symbols.ts
+++ b/lib/project-symbols.ts
@@ -77,7 +77,10 @@ export class ProjectSymbols {
     const config = readConfiguration(this.tsconfigPath);
     this.options = config.options;
     this.compilerHost = createCompilerHost({ options: config.options });
-    this.program = createProgram({ rootNames: config.rootNames, options: config.options, host: this.compilerHost });
+    // Replace all `\` with a forward slash to align with typescript's `normalizePath`.
+    // On Windows, different slashes cause errors while trying to compare module symbols
+    const rootNames = config.rootNames.map(rootName => rootName.replace(/\\/g, '/'));
+    this.program = createProgram({ rootNames, options: config.options, host: this.compilerHost });
     this.init();
     // this.clearCaches();
   }

--- a/test/directive-symbol.spec.ts
+++ b/test/directive-symbol.spec.ts
@@ -73,7 +73,8 @@ describe('DirectiveSymbol', () => {
     it('should read external templates', () => {
       const contextSymbols = new ProjectSymbols(program, resourceResolver, defaultErrorReporter);
       const directive = contextSymbols.getDirectives().pop();
-      expect(directive.getResolvedMetadata().template).toBe(
+      const template = directive.getResolvedMetadata().template.replace(/\r/g, '');
+      expect(template).toBe(
         '{{ a | samplePipe }}\n<div *ngIf="visible">Hello world</div>\n'
       );
       expect(directive.getResolvedMetadata().templateUrl.endsWith('main.component.html')).toBeTruthy();


### PR DESCRIPTION
Unit tests are runnable on Windows as well.

fixes #6