### PR TITLE
define TypeScript as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4258,9 +4258,10 @@
       }
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4258,9 +4258,9 @@
       }
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@angular/compiler": "^7.0.0-rc.0",
     "@angular/compiler-cli": "^7.0.0-rc.0",
     "@angular/core": "^7.0.0-rc.0",
-    "typescript": "~3.1.0"
+    "typescript": "^3.2.0"
   },
   "devDependencies": {
     "@angular/animations": "^7.0.0-rc.0",
@@ -36,7 +36,7 @@
     "rxjs": "^6.3.3",
     "ts-node": "^4.0.0",
     "tslint": "^5.11.0",
-    "typescript": "~3.1.6",
+    "typescript": "^3.2.2",
     "zone.js": "^0.8.26"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "rxjs": "^6.3.3",
     "ts-node": "^4.0.0",
     "tslint": "^5.11.0",
+    "typescript": "~3.1.6",
     "zone.js": "^0.8.26"
   },
   "scripts": {
@@ -51,8 +52,5 @@
     "Compiler"
   ],
   "author": "Minko Gechev <mgechev@gmail.com>",
-  "license": "MIT",
-  "dependencies": {
-    "typescript": "~3.1.0"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
Hi @mgechev,

I discovered today that ngast defines TypeScript as peer dependency and regular dependency at the same time. npm seems to ignore the peer dependency in that case and installs TypeScript as a regular dependency.

When used inside a project which uses TypeScript at version 3.2 this causes a conflict, because ngast is using its local version of TypeScript.

I know that messing around with the package.json in a pull request is only okay if your name is greenkeeper, but I thought it is okay for such an easy fix. Anyway, feel free to just close this pull request if you don't like the changes.